### PR TITLE
[-] group-css-media glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 				"css-loader": "^3.2.0",
 				"extract-text-webpack-plugin": "^3.0.2",
 				"file-loader": "^4.3.0",
-				"group-css-media-queries-loader": "^3.0.2",
 				"image-webpack-loader": "^6.0.0",
 				"mini-css-extract-plugin": "^0.8.0",
 				"node-sass": "^4.13.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,10 +46,6 @@ module.exports = {
 						}
 					},
 					{loader: 'postcss-loader'},
-					{
-						loader: "group-css-media-queries-loader",
-						options: {sourceMap: true}
-					},
 					{loader: 'sass-loader'}
 				],
 			},

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -36,7 +36,6 @@ module.exports = {
 					{loader: MiniCssExtractPlugin.loader},
 					{loader: 'css-loader', options: {url: false, sourceMap: true}},
 					{loader: 'postcss-loader'},
-					{loader: "group-css-media-queries-loader", options: { sourceMap: true }},
 					{loader: 'sass-loader'}
 				],
 			},


### PR DESCRIPTION
groups-css-media created order problems in css queries whether mobilefirst or not. 
for example: 

> the order of the queries is defined by their reading order in the files whereas we would like it to be according to an order of magnitude